### PR TITLE
refactor: use env voice id

### DIFF
--- a/netlify/functions/voice-agent.ts
+++ b/netlify/functions/voice-agent.ts
@@ -6,7 +6,11 @@ interface Message {
 }
 
 const ELEVENLABS_TRANSCRIPTION_URL = 'https://api.elevenlabs.io/v1/transcription';
-const ELEVENLABS_TTS_URL = 'https://api.elevenlabs.io/v1/text-to-speech/LGzcffsz71CPfVxelXqr/stream';
+const ELEVENLABS_VOICE_ID = process.env.ELEVENLABS_VOICE_ID;
+if (!ELEVENLABS_VOICE_ID) {
+  console.warn('Missing ELEVENLABS_VOICE_ID environment variable');
+}
+const ELEVENLABS_TTS_URL = `https://api.elevenlabs.io/v1/text-to-speech/${ELEVENLABS_VOICE_ID}/stream`;
 const OPENROUTER_CHAT_URL = 'https://openrouter.ai/api/v1/chat/completions';
 const OPENROUTER_EMBED_URL = 'https://openrouter.ai/api/v1/embeddings';
 


### PR DESCRIPTION
## Summary
- move ElevenLabs TTS voice ID into environment variable
- warn when ELEVENLABS_VOICE_ID is missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 78 problems, 63 errors)*
- `ELEVENLABS_VOICE_ID=test npm run build:dev` *(fails: SyntaxError in src/App.tsx: Identifier 'ConsultationPage' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b22470dddc8332a4608a34f6b7f48e