### PR TITLE
fix: update voice token endpoint

### DIFF
--- a/src/api/voice.ts
+++ b/src/api/voice.ts
@@ -12,7 +12,7 @@ let stream: MediaStream | null = null;
 export async function startCall(): Promise<Device> {
   if (device) return device;
 
-  const res = await fetch("/.netlify/functions/voice-token");
+  const res = await fetch("/.netlify/functions/generate-twilio-token");
   if (!res.ok) {
     throw new Error(`Voice token request failed: ${res.status} ${res.statusText}`);
   }


### PR DESCRIPTION
## Summary
- point voice call setup at the existing `generate-twilio-token` Netlify function

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in many files)*
- `npm run build:dev` *(fails: build issues and unresolved imports)*

------
https://chatgpt.com/codex/tasks/task_e_68b232900664833293f8b03c4cce07f7